### PR TITLE
[update] 上線前加 noindex meta + 修 README 連結與線上版本資訊

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,17 @@
 
 這是泥日教育 B2B 企業內訓的一頁式 Landing Page，供內部同事預覽、測試與提供修改意見。
 
-**預覽連結** → [niischooleli.github.io/nii-business-landing/nii-business.html](https://niischooleli.github.io/nii-business-landing/nii-business.html)
+## 線上版本
+
+| 環境 | 網址 | 用途 |
+|------|------|------|
+| 正式站（Teachify） | [nii.school/business](https://nii.school/business) | 對外可分享，但目前 `noindex` 中 |
+| 預覽站（GitHub Pages） | [niischool-tw.github.io/nii-business-landing/nii-business.html](https://niischool-tw.github.io/nii-business-landing/nii-business.html) | 此 repo 的最新 HTML 直接渲染 |
+
+> ⚠️ 目前 HTML head 帶有 `<meta name="robots" content="noindex, nofollow">`，搜尋引擎與 AI 爬蟲不會索引此頁。
+> 正式對外公開時，請把這行 meta 拿掉再重新 push（GH Pages 會自動更新）並重新部署 Teachify `/business`。
+>
+> Teachify 版本的圖片仍從 GitHub Pages 的 `images/` 載入，此 repo 是圖片資源來源，請勿任意刪除 `images/` 內檔案。
 
 ---
 
@@ -26,7 +36,7 @@
 
 ### 開一個 Issue
 
-1. 前往頁面上方的 [Issues](https://github.com/niischooleli/nii-business-landing/issues) 分頁
+1. 前往頁面上方的 [Issues](https://github.com/niischool-tw/nii-business-landing/issues) 分頁
 2. 點選右上角的綠色按鈕「**New issue**」
 3. 填寫標題與內容（說明在哪個區塊、看到什麼問題、希望如何調整）
 4. 點「**Submit new issue**」送出

--- a/nii-business.html
+++ b/nii-business.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="robots" content="noindex, nofollow">
 <title>泥日教育 × 企業日文培訓 ｜ Nii Education Business</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary

- `nii-business.html` head 加 `<meta name="robots" content="noindex, nofollow">`，避免正式對外公開前被 Google／AI 爬蟲索引
- README 新增「**線上版本**」區塊，列出 Teachify 正式站（[nii.school/business](https://nii.school/business)）與 GitHub Pages 預覽站，並說明目前 noindex 狀態與圖片資源依賴
- 修正 README 內錯誤的 GitHub 連結：`niischooleli` → `niischool-tw`（原本指向不存在的個人 repo，會出 404）

## Why

頁面已部署到 Teachify `/business`（page id `40056031-c258-4e68-8fe2-246d7c9ef43f`），但尚未對外公開。先前查證：
- HTML 沒有 robots meta
- `nii.school/robots.txt` 對 `/business` 是 `Allow: /`，且 Google／ClaudeBot／GPTBot／PerplexityBot 等都明確 allow
- GitHub Pages 預設允許索引

所以兩邊都需要 noindex 才能擋住索引。Teachify 沒提供原生 password gate / 草稿模式（`published=false` 不擋公開訪問），所以 `meta robots` 是最務實的方案。

## Test walkthrough（給審閱者照做）

### A. 確認 noindex 已生效（merge 後）

1. 等 PR merge 到 `main` 後，GitHub Pages 約 1 分鐘會自動 rebuild
2. 在終端機跑：
   ```bash
   curl -s https://niischool-tw.github.io/nii-business-landing/nii-business.html | grep -i robots
   ```
   **預期**：看到 `<meta name="robots" content="noindex, nofollow">`

### B. 確認 README「線上版本」區塊正確顯示

1. 打開 [niischool-tw/nii-business-landing 首頁](https://github.com/niischool-tw/nii-business-landing)
2. 往下捲到「**線上版本**」表格
3. **預期**：看到 2 列（Teachify 正式站、GitHub Pages 預覽站），點兩個連結都能打開（Teachify 那條可能需要等我重部署）

### C. 確認 Issues 連結修正

1. 在 README 點「前往頁面上方的 Issues 分頁」連結
2. **預期**：跳到 `niischool-tw/nii-business-landing/issues`（不是 404）

### D. 我會做的後續（不在這個 PR scope）

PR merge 後我會：
1. 從 `main` 拉新版 `nii-business.html`
2. 重新 rewrite 圖片路徑為 GitHub Pages 絕對 URL
3. 走 `prepare_deployment` + `request_asset_upload` + `complete_deployment` + `promote_deployment` 重新部署 Teachify `/business`
4. `curl https://nii.school/business | grep robots` 驗證 noindex 已在 Teachify 那邊生效

## 順手發現、不在這個 PR 修的問題

- README 第 48-53 行的 Issue 標籤說明（`bug` / `enhancement` / `content` / `question`）與我們已有的 `[bug]` / `[feature]` / `[update]` 三選一前綴規則不一致。建議另開一個 issue 統一規則，這個 PR 不動避免 scope creep。

🤖 Generated with [Claude Code](https://claude.com/claude-code)